### PR TITLE
A node that declares itself to be part of one app cluster cannot join a node in a different app cluster.

### DIFF
--- a/lib/swim.js
+++ b/lib/swim.js
@@ -70,6 +70,7 @@ AdminJoiner.prototype.sendJoin = function sendJoin() {
     };
     var local = this.ringpop.membership.localMember;
     var body = {
+        app: this.ringpop.app,
         source: local.address,
         incarnationNumber: local.incarnationNumber
     };
@@ -107,9 +108,9 @@ AdminJoiner.prototype.onJoin = function onJoin(err, res1, res2) {
     if (err) {
         this.ringpop.logger.warn('join cluster failed', {
             err: err.message,
-            address: this.ringpop.hostPort,
-            app: this.ringpop.app,
-            receiver: this.currentPeer,
+            senderAddress: this.ringpop.hostPort,
+            senderApp: this.ringpop.app,
+            receiverAddress: this.currentPeer,
             numJoined: Object.keys(this.peersJoined).length,
             numToJoin: this.peersToJoin,
             currentJoinDuration: new Date() - this.joinStart,
@@ -126,9 +127,9 @@ AdminJoiner.prototype.onJoin = function onJoin(err, res1, res2) {
     var membership = bodyObj && bodyObj.membership;
 
     this.ringpop.logger.info('joined cluster', {
-        address: this.ringpop.hostPort,
-        app: this.ringpop.app,
-        receiver: coordinator,
+        senderAddress: this.ringpop.hostPort,
+        senderApp: this.ringpop.app,
+        receiverAddress: coordinator,
         receiverApp: bodyObj.app,
         numJoined: Object.keys(this.peersJoined).length,
         numToJoin: this.peersToJoin

--- a/lib/tchannel.js
+++ b/lib/tchannel.js
@@ -122,13 +122,15 @@ RingPopTChannel.prototype.protocolJoin = function (arg1, arg2, hostInfo, cb) {
         return cb(new Error('need JSON req body with source and incarnationNumber'));
     }
 
+    var app = body.app;
     var source = body.source;
     var incarnationNumber = body.incarnationNumber;
-    if (source === undefined || incarnationNumber === undefined) {
-        return cb(new Error('need req body with source and incarnationNumber'));
+    if (app === undefined || source === undefined || incarnationNumber === undefined) {
+        return cb(new Error('need req body with app, source and incarnationNumber'));
     }
 
     this.ringPop.protocolJoin({
+        app: app,
         source: source,
         incarnationNumber: incarnationNumber
     }, function(err, res) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "opn": "^1.0.1",
     "pre-commit": "^0.0.9",
     "tape": "^3.0.3",
-    "tchannel": "git+ssh://git@github.com:uber/tchannel#v1.2.1",
+    "tchannel": "git+ssh://git@github.com:uber/tchannel#v1.2.4",
     "time-mock": "^0.1.2",
     "tryit": "^1.0.1"
   },

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -52,3 +52,28 @@ test('key hashes to only server', function t(assert) {
     ringpop.destroy();
     assert.end();
 });
+
+test('protocol join disallows joining itself', function t(assert) {
+    assert.plan(2);
+
+    var itself = '127.0.0.1:3000';
+    var ringpop = new RingPop({ app: 'ringpop', hostPort: itself });
+    ringpop.protocolJoin({ source: itself }, function(err) {
+        assert.ok(err, 'an error occurred');
+        assert.equals(err.type, 'ringpop.invalid-join.source', 'a node cannot join itself');
+        assert.end();
+    });
+});
+
+test('protocol join disallows joining different app clusters', function t(assert) {
+    assert.plan(2);
+
+    var node1 = { app: 'mars', hostPort: '127.0.0.1:3000' };
+    var node2 = { app: 'jupiter', source: '127.0.0.1:3001' };
+    var ringpop = new RingPop(node1);
+    ringpop.protocolJoin(node2, function(err) {
+        assert.ok(err, 'an error occurred');
+        assert.equals(err.type, 'ringpop.invalid-join.app', 'a node cannot join a different app cluster');
+        assert.end();
+    });
+});


### PR DESCRIPTION
Eventually, we need to extract the join logic into it's own class and stop making `index.js` bloated. That time is coming near.

This PR prevents nodes declaring themselves part of different apps from joining one another.

@Raynos @mranney 
