### PR TITLE
update hammock for node4+ support

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "body": "^5.0.0",
     "error": "^5.0.0",
     "farmhash": "^1.2.0",
-    "hammock": "^2.0.1",
+    "hammock": "^3.0.1",
     "metrics": "^0.1.8",
     "node-uuid": "^1.4.3",
     "toobusy-js": "^0.5.0",


### PR DESCRIPTION
Simple change bumps hammock to do the right thing in node versions later than 0.10. This module is used to do request forwarding and needs to be corrected for changes in behavior to req/res headers and some streams related issues.